### PR TITLE
Add Ruff to CI and clean lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Verify environment
         run: uv pip check
 
+      - name: Run Ruff
+        run: uv run ruff check .
+
       - name: Run tests
         run: uv run pytest

--- a/notebooks/Medical_Insurance.ipynb
+++ b/notebooks/Medical_Insurance.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Medical Insurance Cost Prediction\n",
@@ -15,9 +16,7 @@
    "id": "830abb44",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from google.colab import files\n"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -71,9 +70,9 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
+    "\n",
     "%matplotlib inline"
    ]
   },
@@ -84,29 +83,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.preprocessing import LabelEncoder\n",
     "from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score\n",
-    "from sklearn.preprocessing import StandardScaler\n",
     "from sklearn.preprocessing import OneHotEncoder, MinMaxScaler\n",
-    "from sklearn.pipeline import Pipeline\n",
     "from sklearn.compose import ColumnTransformer\n",
-    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from sklearn.preprocessing import OrdinalEncoder\n",
     "import scipy.stats as stats\n",
-    "import seaborn as sns\n",
-    "import matplotlib.pyplot as plt\n",
-    "from sklearn.linear_model import LogisticRegression, LinearRegression, BayesianRidge\n",
+    "from sklearn.linear_model import LinearRegression, BayesianRidge\n",
     "from sklearn.ensemble import RandomForestRegressor, AdaBoostRegressor\n",
     "from sklearn.svm import SVR\n",
-    "from sklearn.naive_bayes import GaussianNB\n",
-    "from sklearn.utils.class_weight import compute_class_weight\n",
-    "from sklearn.metrics import accuracy_score, precision_score, recall_score, confusion_matrix, classification_report, f1_score\n",
-    "from sklearn import metrics\n",
     "from sklearn.model_selection import GridSearchCV\n",
     "from sklearn.model_selection import cross_val_score\n",
+    "\n",
     "sns.set_theme(style=\"white\")\n",
-    "palette=['#B0C4DE','#006400','#0099CC','#CCFFFF']"
+    "palette = [\"#B0C4DE\", \"#006400\", \"#0099CC\", \"#CCFFFF\"]"
    ]
   },
   {
@@ -136,12 +125,15 @@
    "source": [
     "import os\n",
     "\n",
-    "csv_path = next((os.path.join(path, f) for f in os.listdir(path) if f.lower().endswith('.csv')), None)\n",
+    "csv_path = next(\n",
+    "    (os.path.join(path, f) for f in os.listdir(path) if f.lower().endswith(\".csv\")),\n",
+    "    None,\n",
+    ")\n",
     "if csv_path is None:\n",
-    "    raise FileNotFoundError(f'No CSV found in {path}')\n",
+    "    raise FileNotFoundError(f\"No CSV found in {path}\")\n",
     "\n",
     "dataset = pd.read_csv(csv_path)\n",
-    "print('Loaded:', csv_path, 'rows:', len(dataset))\n"
+    "print(\"Loaded:\", csv_path, \"rows:\", len(dataset))"
    ]
   },
   {
@@ -206,7 +198,7 @@
     }
    ],
    "source": [
-    "dataset.shape\n"
+    "dataset.shape"
    ]
   },
   {
@@ -493,7 +485,7 @@
     }
    ],
    "source": [
-    "dataset.describe(include=\"all\").T\n"
+    "dataset.describe(include=\"all\").T"
    ]
   },
   {
@@ -614,11 +606,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "object_cols=dataset.select_dtypes(include=['object']).columns.tolist()\n",
-    "int_cols=dataset.select_dtypes(include=['int64']).columns.tolist()\n",
-    "float_cols=dataset.select_dtypes(include=['float64']).columns.tolist()\n",
-    "numeric_cols=int_cols+float_cols\n",
-    "target_column='charges'"
+    "object_cols = dataset.select_dtypes(include=[\"object\"]).columns.tolist()\n",
+    "int_cols = dataset.select_dtypes(include=[\"int64\"]).columns.tolist()\n",
+    "float_cols = dataset.select_dtypes(include=[\"float64\"]).columns.tolist()\n",
+    "numeric_cols = int_cols + float_cols\n",
+    "target_column = \"charges\""
    ]
   },
   {
@@ -685,7 +677,7 @@
    ],
    "source": [
     "# Duplicates count\n",
-    "dataset.duplicated().sum()\n"
+    "dataset.duplicated().sum()"
    ]
   },
   {
@@ -714,7 +706,7 @@
     }
    ],
    "source": [
-    "unique_counts = dataset[object_cols].nunique() \n",
+    "unique_counts = dataset[object_cols].nunique()\n",
     "print(unique_counts)"
    ]
   },
@@ -735,36 +727,50 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Functions\n",
+    "# Functions\n",
+    "\n",
     "\n",
     "def create_boxplot_chart(dataset, statistics_column, target_column):\n",
-    "    plt.figure(figsize=(10, 6)) \n",
-    "    distribution=sns.boxplot(data=dataset,x=statistics_column, y=target_column, palette=palette)\n",
-    "    #if len(dataset[statistics_column].unique()) > 2:\n",
-    "     #    plt.xticks(rotation=90)\n",
+    "    plt.figure(figsize=(10, 6))\n",
+    "    distribution = sns.boxplot(\n",
+    "        data=dataset, x=statistics_column, y=target_column, palette=palette\n",
+    "    )\n",
+    "    # if len(dataset[statistics_column].unique()) > 2:\n",
+    "    #    plt.xticks(rotation=90)\n",
     "\n",
-    "def create_pie_chart(dataset,statistics_column, target_column):\n",
-    "    value_count=dataset[statistics_column].value_counts()\n",
-    "    plt.figure(figsize=(10, 6)) \n",
-    "    plt.pie(value_count,labels=value_count.index,colors=palette)\n",
+    "\n",
+    "def create_pie_chart(dataset, statistics_column, target_column):\n",
+    "    value_count = dataset[statistics_column].value_counts()\n",
+    "    plt.figure(figsize=(10, 6))\n",
+    "    plt.pie(value_count, labels=value_count.index, colors=palette)\n",
     "    plt.title(statistics_column)\n",
     "\n",
-    "def create_scatter_chart(dataset,statistics_column, target_column):\n",
-    "    plt.figure(figsize=(10, 6)) \n",
+    "\n",
+    "def create_scatter_chart(dataset, statistics_column, target_column):\n",
+    "    plt.figure(figsize=(10, 6))\n",
     "    plt.scatter(dataset[statistics_column], dataset[target_column])\n",
     "    plt.xlabel(statistics_column)\n",
     "    plt.ylabel(target_column)\n",
     "    plt.show()\n",
     "\n",
-    "def create_kde_chart(dataset,statistics_column, target_column):\n",
+    "\n",
+    "def create_kde_chart(dataset, statistics_column, target_column):\n",
     "    plt.figure(figsize=(10, 6))\n",
-    "    if target_column==\"\" :\n",
-    "        sns.kdeplot(x=dataset[statistics_column], fill=True, multiple='layer',legend=True)  \n",
-    "        plt.ylabel('Density')\n",
-    "    else :\n",
-    "        sns.kdeplot(x=dataset[statistics_column], y=dataset[target_column], fill=True, multiple='layer',legend=True) \n",
+    "    if target_column == \"\":\n",
+    "        sns.kdeplot(\n",
+    "            x=dataset[statistics_column], fill=True, multiple=\"layer\", legend=True\n",
+    "        )\n",
+    "        plt.ylabel(\"Density\")\n",
+    "    else:\n",
+    "        sns.kdeplot(\n",
+    "            x=dataset[statistics_column],\n",
+    "            y=dataset[target_column],\n",
+    "            fill=True,\n",
+    "            multiple=\"layer\",\n",
+    "            legend=True,\n",
+    "        )\n",
     "        plt.ylabel(target_column)\n",
-    "    plt.title('Smooth Histogram (KDE)')\n",
+    "    plt.title(\"Smooth Histogram (KDE)\")\n",
     "    plt.xlabel(statistics_column)"
    ]
   },
@@ -817,7 +823,7 @@
    ],
    "source": [
     "for col in object_cols:\n",
-    "    create_pie_chart(dataset,col,target_column)"
+    "    create_pie_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -894,7 +900,7 @@
    ],
    "source": [
     "for col in object_cols:\n",
-    "   create_boxplot_chart(dataset,col,target_column)"
+    "    create_boxplot_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -956,7 +962,7 @@
    ],
    "source": [
     "for col in numeric_cols:\n",
-    "   create_scatter_chart(dataset,col,target_column)"
+    "    create_scatter_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -1066,8 +1072,8 @@
    ],
    "source": [
     "for col in numeric_cols:\n",
-    "   create_kde_chart(dataset,col, \"\")\n",
-    "   create_kde_chart(dataset,col,target_column)"
+    "    create_kde_chart(dataset, col, \"\")\n",
+    "    create_kde_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -1128,11 +1134,10 @@
     }
    ],
    "source": [
-    "import scipy.stats as stats\n",
     "for col in numeric_cols:\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    stats.probplot(dataset[col], dist=\"norm\", plot=plt)\n",
-    "    plt.title('Q-Q Plot for '+col)\n",
+    "    plt.title(\"Q-Q Plot for \" + col)\n",
     "    plt.show()"
    ]
   },
@@ -1153,7 +1158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_corelation_analysis=dataset"
+    "df_corelation_analysis = dataset"
    ]
   },
   {
@@ -1163,7 +1168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_encoded=pd.get_dummies(df_corelation_analysis)"
+    "df_encoded = pd.get_dummies(df_corelation_analysis)"
    ]
   },
   {
@@ -1194,7 +1199,7 @@
     }
    ],
    "source": [
-    "corr=df_encoded.corr()\n",
+    "corr = df_encoded.corr()\n",
     "plt.figure(figsize=(6, 6))\n",
     "sns.heatmap(corr)"
    ]
@@ -1220,14 +1225,15 @@
     "    model_name, model = model_tuple\n",
     "    print(f\"Training {model_name}...\")\n",
     "    model.fit(X_train, y_train)\n",
-    "    y_train_pred=model.predict(X_train)\n",
-    "    y_test_pred=model.predict(X_test)\n",
-    "    evaluate_model(\"Train\",y_train,y_train_pred)\n",
-    "    evaluate_model(\"Test\",y_test,y_test_pred)\n",
-    "    \n",
+    "    y_train_pred = model.predict(X_train)\n",
+    "    y_test_pred = model.predict(X_test)\n",
+    "    evaluate_model(\"Train\", y_train, y_train_pred)\n",
+    "    evaluate_model(\"Test\", y_test, y_test_pred)\n",
+    "\n",
+    "\n",
     "def evaluate_model(train_or_test, y_actual, y_predicted):\n",
     "    print()\n",
-    "    \n",
+    "\n",
     "    mae = mean_absolute_error(y_actual, y_predicted)\n",
     "    mse = mean_squared_error(y_actual, y_predicted)\n",
     "    r2 = r2_score(y_actual, y_predicted)\n",
@@ -1235,16 +1241,16 @@
     "    print(f\"{train_or_test} Mean Absolute Error (MAE): {mae:.4f}\")\n",
     "    print(f\"{train_or_test} Mean Squared Error (MSE): {mse:.4f}\")\n",
     "    print(f\"{train_or_test} R-squared (R²) Score: {r2:.4f}\")\n",
-    "    \n",
+    "\n",
     "    print(\"-\" * 50)\n",
     "\n",
     "\n",
     "models = [\n",
-    "    ('Random Forest', RandomForestRegressor()),\n",
-    "    ('Linear Regression', LinearRegression()),\n",
-    "    ('Support Vector Machine', SVR()),\n",
-    "    ('Naive Bayes', BayesianRidge()),  \n",
-    "    ('AdaBoost', AdaBoostRegressor())\n",
+    "    (\"Random Forest\", RandomForestRegressor()),\n",
+    "    (\"Linear Regression\", LinearRegression()),\n",
+    "    (\"Support Vector Machine\", SVR()),\n",
+    "    (\"Naive Bayes\", BayesianRidge()),\n",
+    "    (\"AdaBoost\", AdaBoostRegressor()),\n",
     "]"
    ]
   },
@@ -1265,12 +1271,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "multicolumn_prep = ColumnTransformer([\n",
-    "    #('drop', 'drop', ['State', 'PatientID']),\n",
-    "    #('handle_missing', SimpleImputer(missing_values=np.nan, strategy='most_frequent')),\n",
-    "    ('encode_multicategorical', OneHotEncoder(sparse_output=False), ['sex','region','smoker']),\n",
-    "    ('feature_scaling', MinMaxScaler(), ['children','bmi'])\n",
-    "], remainder='passthrough')"
+    "multicolumn_prep = ColumnTransformer(\n",
+    "    [\n",
+    "        # ('drop', 'drop', ['State', 'PatientID']),\n",
+    "        # ('handle_missing', SimpleImputer(missing_values=np.nan, strategy='most_frequent')),\n",
+    "        (\n",
+    "            \"encode_multicategorical\",\n",
+    "            OneHotEncoder(sparse_output=False),\n",
+    "            [\"sex\", \"region\", \"smoker\"],\n",
+    "        ),\n",
+    "        (\"feature_scaling\", MinMaxScaler(), [\"children\", \"bmi\"]),\n",
+    "    ],\n",
+    "    remainder=\"passthrough\",\n",
+    ")"
    ]
   },
   {
@@ -1290,9 +1303,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X=dataset.drop(target_column, axis=1)\n",
-    "y=dataset[target_column]\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X, y,test_size=0.7, random_state=21)"
+    "X = dataset.drop(target_column, axis=1)\n",
+    "y = dataset[target_column]\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.7, random_state=21\n",
+    ")"
    ]
   },
   {
@@ -1302,8 +1317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train_preprocessed=multicolumn_prep.fit_transform(X_train)\n",
-    "X_test_preprocessed=multicolumn_prep.transform(X_test)"
+    "X_train_preprocessed = multicolumn_prep.fit_transform(X_train)\n",
+    "X_test_preprocessed = multicolumn_prep.transform(X_test)"
    ]
   },
   {
@@ -1376,7 +1391,9 @@
    ],
    "source": [
     "for model in models:\n",
-    "    create_model_and_predictions(model, X_train_preprocessed, y_train, X_test_preprocessed, y_test)"
+    "    create_model_and_predictions(\n",
+    "        model, X_train_preprocessed, y_train, X_test_preprocessed, y_test\n",
+    "    )"
    ]
   },
   {
@@ -1406,8 +1423,10 @@
     }
    ],
    "source": [
-    "model=RandomForestRegressor()\n",
-    "cross_validation=cross_val_score(model,X_train_preprocessed,y_train, scoring='r2', cv=10)\n",
+    "model = RandomForestRegressor()\n",
+    "cross_validation = cross_val_score(\n",
+    "    model, X_train_preprocessed, y_train, scoring=\"r2\", cv=10\n",
+    ")\n",
     "print(\"Cross-validation scores for each fold:\", cross_validation)\n",
     "\n",
     "print(\"Average cross-validation score:\", cross_validation.mean())"
@@ -1415,6 +1434,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Hyperparameter tuning\n",
@@ -1436,7 +1456,7 @@
     "    \"min_samples_leaf\": [1, 2],\n",
     "    \"max_features\": [\"sqrt\", \"log2\", None],\n",
     "    \"bootstrap\": [True, False],\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -1457,8 +1477,8 @@
    "source": [
     "model = RandomForestRegressor()\n",
     "\n",
-    "grid_search = GridSearchCV(estimator=model, param_grid=param_grid,scoring='r2', cv=10)\n",
-    "grid_search.fit(X_train_preprocessed,y_train)\n",
+    "grid_search = GridSearchCV(estimator=model, param_grid=param_grid, scoring=\"r2\", cv=10)\n",
+    "grid_search.fit(X_train_preprocessed, y_train)\n",
     "\n",
     "print(\"Best Hyperparameters: \", grid_search.best_params_)\n",
     "print(\"Best Score: \", grid_search.best_score_)"

--- a/notebooks/Medical_Insurance_02.ipynb
+++ b/notebooks/Medical_Insurance_02.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Medical Insurance Cost Prediction\n",
@@ -15,9 +16,7 @@
    "id": "830abb44",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from google.colab import files\n"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -71,9 +70,9 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
+    "\n",
     "%matplotlib inline"
    ]
   },
@@ -84,29 +83,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.preprocessing import LabelEncoder\n",
     "from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score\n",
-    "from sklearn.preprocessing import StandardScaler\n",
     "from sklearn.preprocessing import OneHotEncoder, MinMaxScaler\n",
-    "from sklearn.pipeline import Pipeline\n",
     "from sklearn.compose import ColumnTransformer\n",
-    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from sklearn.preprocessing import OrdinalEncoder\n",
     "import scipy.stats as stats\n",
-    "import seaborn as sns\n",
-    "import matplotlib.pyplot as plt\n",
-    "from sklearn.linear_model import LogisticRegression, LinearRegression, BayesianRidge\n",
+    "from sklearn.linear_model import LinearRegression, BayesianRidge\n",
     "from sklearn.ensemble import RandomForestRegressor, AdaBoostRegressor\n",
     "from sklearn.svm import SVR\n",
-    "from sklearn.naive_bayes import GaussianNB\n",
-    "from sklearn.utils.class_weight import compute_class_weight\n",
-    "from sklearn.metrics import accuracy_score, precision_score, recall_score, confusion_matrix, classification_report, f1_score\n",
-    "from sklearn import metrics\n",
     "from sklearn.model_selection import GridSearchCV\n",
     "from sklearn.model_selection import cross_val_score\n",
+    "\n",
     "sns.set_theme(style=\"white\")\n",
-    "palette=['#B0C4DE','#006400','#0099CC','#CCFFFF']"
+    "palette = [\"#B0C4DE\", \"#006400\", \"#0099CC\", \"#CCFFFF\"]"
    ]
   },
   {
@@ -136,12 +125,15 @@
    "source": [
     "import os\n",
     "\n",
-    "csv_path = next((os.path.join(path, f) for f in os.listdir(path) if f.lower().endswith('.csv')), None)\n",
+    "csv_path = next(\n",
+    "    (os.path.join(path, f) for f in os.listdir(path) if f.lower().endswith(\".csv\")),\n",
+    "    None,\n",
+    ")\n",
     "if csv_path is None:\n",
-    "    raise FileNotFoundError(f'No CSV found in {path}')\n",
+    "    raise FileNotFoundError(f\"No CSV found in {path}\")\n",
     "\n",
     "dataset = pd.read_csv(csv_path)\n",
-    "print('Loaded:', csv_path, 'rows:', len(dataset))\n"
+    "print(\"Loaded:\", csv_path, \"rows:\", len(dataset))"
    ]
   },
   {
@@ -206,7 +198,7 @@
     }
    ],
    "source": [
-    "dataset.shape\n"
+    "dataset.shape"
    ]
   },
   {
@@ -493,7 +485,7 @@
     }
    ],
    "source": [
-    "dataset.describe(include=\"all\").T\n"
+    "dataset.describe(include=\"all\").T"
    ]
   },
   {
@@ -614,11 +606,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "object_cols=dataset.select_dtypes(include=['object']).columns.tolist()\n",
-    "int_cols=dataset.select_dtypes(include=['int64']).columns.tolist()\n",
-    "float_cols=dataset.select_dtypes(include=['float64']).columns.tolist()\n",
-    "numeric_cols=int_cols+float_cols\n",
-    "target_column='charges'"
+    "object_cols = dataset.select_dtypes(include=[\"object\"]).columns.tolist()\n",
+    "int_cols = dataset.select_dtypes(include=[\"int64\"]).columns.tolist()\n",
+    "float_cols = dataset.select_dtypes(include=[\"float64\"]).columns.tolist()\n",
+    "numeric_cols = int_cols + float_cols\n",
+    "target_column = \"charges\""
    ]
   },
   {
@@ -685,7 +677,7 @@
    ],
    "source": [
     "# Duplicates count\n",
-    "dataset.duplicated().sum()\n"
+    "dataset.duplicated().sum()"
    ]
   },
   {
@@ -714,7 +706,7 @@
     }
    ],
    "source": [
-    "unique_counts = dataset[object_cols].nunique() \n",
+    "unique_counts = dataset[object_cols].nunique()\n",
     "print(unique_counts)"
    ]
   },
@@ -735,36 +727,50 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Functions\n",
+    "# Functions\n",
+    "\n",
     "\n",
     "def create_boxplot_chart(dataset, statistics_column, target_column):\n",
-    "    plt.figure(figsize=(10, 6)) \n",
-    "    distribution=sns.boxplot(data=dataset,x=statistics_column, y=target_column, palette=palette)\n",
-    "    #if len(dataset[statistics_column].unique()) > 2:\n",
-    "     #    plt.xticks(rotation=90)\n",
+    "    plt.figure(figsize=(10, 6))\n",
+    "    distribution = sns.boxplot(\n",
+    "        data=dataset, x=statistics_column, y=target_column, palette=palette\n",
+    "    )\n",
+    "    # if len(dataset[statistics_column].unique()) > 2:\n",
+    "    #    plt.xticks(rotation=90)\n",
     "\n",
-    "def create_pie_chart(dataset,statistics_column, target_column):\n",
-    "    value_count=dataset[statistics_column].value_counts()\n",
-    "    plt.figure(figsize=(10, 6)) \n",
-    "    plt.pie(value_count,labels=value_count.index,colors=palette)\n",
+    "\n",
+    "def create_pie_chart(dataset, statistics_column, target_column):\n",
+    "    value_count = dataset[statistics_column].value_counts()\n",
+    "    plt.figure(figsize=(10, 6))\n",
+    "    plt.pie(value_count, labels=value_count.index, colors=palette)\n",
     "    plt.title(statistics_column)\n",
     "\n",
-    "def create_scatter_chart(dataset,statistics_column, target_column):\n",
-    "    plt.figure(figsize=(10, 6)) \n",
+    "\n",
+    "def create_scatter_chart(dataset, statistics_column, target_column):\n",
+    "    plt.figure(figsize=(10, 6))\n",
     "    plt.scatter(dataset[statistics_column], dataset[target_column])\n",
     "    plt.xlabel(statistics_column)\n",
     "    plt.ylabel(target_column)\n",
     "    plt.show()\n",
     "\n",
-    "def create_kde_chart(dataset,statistics_column, target_column):\n",
+    "\n",
+    "def create_kde_chart(dataset, statistics_column, target_column):\n",
     "    plt.figure(figsize=(10, 6))\n",
-    "    if target_column==\"\" :\n",
-    "        sns.kdeplot(x=dataset[statistics_column], fill=True, multiple='layer',legend=True)  \n",
-    "        plt.ylabel('Density')\n",
-    "    else :\n",
-    "        sns.kdeplot(x=dataset[statistics_column], y=dataset[target_column], fill=True, multiple='layer',legend=True) \n",
+    "    if target_column == \"\":\n",
+    "        sns.kdeplot(\n",
+    "            x=dataset[statistics_column], fill=True, multiple=\"layer\", legend=True\n",
+    "        )\n",
+    "        plt.ylabel(\"Density\")\n",
+    "    else:\n",
+    "        sns.kdeplot(\n",
+    "            x=dataset[statistics_column],\n",
+    "            y=dataset[target_column],\n",
+    "            fill=True,\n",
+    "            multiple=\"layer\",\n",
+    "            legend=True,\n",
+    "        )\n",
     "        plt.ylabel(target_column)\n",
-    "    plt.title('Smooth Histogram (KDE)')\n",
+    "    plt.title(\"Smooth Histogram (KDE)\")\n",
     "    plt.xlabel(statistics_column)"
    ]
   },
@@ -817,7 +823,7 @@
    ],
    "source": [
     "for col in object_cols:\n",
-    "    create_pie_chart(dataset,col,target_column)"
+    "    create_pie_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -894,7 +900,7 @@
    ],
    "source": [
     "for col in object_cols:\n",
-    "   create_boxplot_chart(dataset,col,target_column)"
+    "    create_boxplot_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -956,7 +962,7 @@
    ],
    "source": [
     "for col in numeric_cols:\n",
-    "   create_scatter_chart(dataset,col,target_column)"
+    "    create_scatter_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -1066,8 +1072,8 @@
    ],
    "source": [
     "for col in numeric_cols:\n",
-    "   create_kde_chart(dataset,col, \"\")\n",
-    "   create_kde_chart(dataset,col,target_column)"
+    "    create_kde_chart(dataset, col, \"\")\n",
+    "    create_kde_chart(dataset, col, target_column)"
    ]
   },
   {
@@ -1128,11 +1134,10 @@
     }
    ],
    "source": [
-    "import scipy.stats as stats\n",
     "for col in numeric_cols:\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    stats.probplot(dataset[col], dist=\"norm\", plot=plt)\n",
-    "    plt.title('Q-Q Plot for '+col)\n",
+    "    plt.title(\"Q-Q Plot for \" + col)\n",
     "    plt.show()"
    ]
   },
@@ -1153,7 +1158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_corelation_analysis=dataset"
+    "df_corelation_analysis = dataset"
    ]
   },
   {
@@ -1163,7 +1168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_encoded=pd.get_dummies(df_corelation_analysis)"
+    "df_encoded = pd.get_dummies(df_corelation_analysis)"
    ]
   },
   {
@@ -1194,7 +1199,7 @@
     }
    ],
    "source": [
-    "corr=df_encoded.corr()\n",
+    "corr = df_encoded.corr()\n",
     "plt.figure(figsize=(6, 6))\n",
     "sns.heatmap(corr)"
    ]
@@ -1220,31 +1225,32 @@
     "    model_name, model = model_tuple\n",
     "    print(f\"Training {model_name}...\")\n",
     "    model.fit(X_train, y_train)\n",
-    "    y_train_pred=model.predict(X_train)\n",
-    "    y_test_pred=model.predict(X_test)\n",
-    "    evaluate_model(\"Train\",y_train,y_train_pred)\n",
-    "    evaluate_model(\"Test\",y_test,y_test_pred)\n",
-    "    \n",
+    "    y_train_pred = model.predict(X_train)\n",
+    "    y_test_pred = model.predict(X_test)\n",
+    "    evaluate_model(\"Train\", y_train, y_train_pred)\n",
+    "    evaluate_model(\"Test\", y_test, y_test_pred)\n",
+    "\n",
+    "\n",
     "def evaluate_model(train_or_test, y_actual, y_predicted):\n",
     "    print()\n",
-    "    \n",
+    "\n",
     "    mae = mean_absolute_error(y_actual, y_predicted)\n",
     "    mse = mean_squared_error(y_actual, y_predicted)\n",
     "    r2 = r2_score(y_actual, y_predicted)\n",
     "\n",
     "    print(f\"{train_or_test} Mean Absolute Error (MAE): {mae:.4f}\")\n",
     "    print(f\"{train_or_test} Mean Squared Error (MSE): {mse:.4f}\")\n",
-    "    print(f\"{train_or_test} R-squared (R\u00b2) Score: {r2:.4f}\")\n",
-    "    \n",
+    "    print(f\"{train_or_test} R-squared (R²) Score: {r2:.4f}\")\n",
+    "\n",
     "    print(\"-\" * 50)\n",
     "\n",
     "\n",
     "models = [\n",
-    "    ('Random Forest', RandomForestRegressor()),\n",
-    "    ('Linear Regression', LinearRegression()),\n",
-    "    ('Support Vector Machine', SVR()),\n",
-    "    ('Naive Bayes', BayesianRidge()),  \n",
-    "    ('AdaBoost', AdaBoostRegressor())\n",
+    "    (\"Random Forest\", RandomForestRegressor()),\n",
+    "    (\"Linear Regression\", LinearRegression()),\n",
+    "    (\"Support Vector Machine\", SVR()),\n",
+    "    (\"Naive Bayes\", BayesianRidge()),\n",
+    "    (\"AdaBoost\", AdaBoostRegressor()),\n",
     "]"
    ]
   },
@@ -1265,12 +1271,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "multicolumn_prep = ColumnTransformer([\n",
-    "    #('drop', 'drop', ['State', 'PatientID']),\n",
-    "    #('handle_missing', SimpleImputer(missing_values=np.nan, strategy='most_frequent')),\n",
-    "    ('encode_multicategorical', OneHotEncoder(sparse_output=False), ['sex','region','smoker']),\n",
-    "    ('feature_scaling', MinMaxScaler(), ['children','bmi'])\n",
-    "], remainder='passthrough')"
+    "multicolumn_prep = ColumnTransformer(\n",
+    "    [\n",
+    "        # ('drop', 'drop', ['State', 'PatientID']),\n",
+    "        # ('handle_missing', SimpleImputer(missing_values=np.nan, strategy='most_frequent')),\n",
+    "        (\n",
+    "            \"encode_multicategorical\",\n",
+    "            OneHotEncoder(sparse_output=False),\n",
+    "            [\"sex\", \"region\", \"smoker\"],\n",
+    "        ),\n",
+    "        (\"feature_scaling\", MinMaxScaler(), [\"children\", \"bmi\"]),\n",
+    "    ],\n",
+    "    remainder=\"passthrough\",\n",
+    ")"
    ]
   },
   {
@@ -1290,9 +1303,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X=dataset.drop(target_column, axis=1)\n",
-    "y=dataset[target_column]\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X, y,test_size=0.7, random_state=21)"
+    "X = dataset.drop(target_column, axis=1)\n",
+    "y = dataset[target_column]\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.7, random_state=21\n",
+    ")"
    ]
   },
   {
@@ -1302,8 +1317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train_preprocessed=multicolumn_prep.fit_transform(X_train)\n",
-    "X_test_preprocessed=multicolumn_prep.transform(X_test)"
+    "X_train_preprocessed = multicolumn_prep.fit_transform(X_train)\n",
+    "X_test_preprocessed = multicolumn_prep.transform(X_test)"
    ]
   },
   {
@@ -1320,63 +1335,65 @@
       "\n",
       "Train Mean Absolute Error (MAE): 758.7999\n",
       "Train Mean Squared Error (MSE): 2311264.9457\n",
-      "Train R-squared (R\u00b2) Score: 0.9850\n",
+      "Train R-squared (R²) Score: 0.9850\n",
       "--------------------------------------------------\n",
       "\n",
       "Test Mean Absolute Error (MAE): 2209.2809\n",
       "Test Mean Squared Error (MSE): 19066492.3985\n",
-      "Test R-squared (R\u00b2) Score: 0.8683\n",
+      "Test R-squared (R²) Score: 0.8683\n",
       "--------------------------------------------------\n",
       "Training Linear Regression...\n",
       "\n",
       "Train Mean Absolute Error (MAE): 4352.5935\n",
       "Train Mean Squared Error (MSE): 39578355.1575\n",
-      "Train R-squared (R\u00b2) Score: 0.7435\n",
+      "Train R-squared (R²) Score: 0.7435\n",
       "--------------------------------------------------\n",
       "\n",
       "Test Mean Absolute Error (MAE): 4120.2618\n",
       "Test Mean Squared Error (MSE): 35802170.9454\n",
-      "Test R-squared (R\u00b2) Score: 0.7527\n",
+      "Test R-squared (R²) Score: 0.7527\n",
       "--------------------------------------------------\n",
       "Training Support Vector Machine...\n",
       "\n",
       "Train Mean Absolute Error (MAE): 8491.8529\n",
       "Train Mean Squared Error (MSE): 172567980.0393\n",
-      "Train R-squared (R\u00b2) Score: -0.1183\n",
+      "Train R-squared (R²) Score: -0.1183\n",
       "--------------------------------------------------\n",
       "\n",
       "Test Mean Absolute Error (MAE): 8272.8011\n",
       "Test Mean Squared Error (MSE): 163115808.3925\n",
-      "Test R-squared (R\u00b2) Score: -0.1269\n",
+      "Test R-squared (R²) Score: -0.1269\n",
       "--------------------------------------------------\n",
       "Training Naive Bayes...\n",
       "\n",
       "Train Mean Absolute Error (MAE): 4337.2766\n",
       "Train Mean Squared Error (MSE): 39583674.8228\n",
-      "Train R-squared (R\u00b2) Score: 0.7435\n",
+      "Train R-squared (R²) Score: 0.7435\n",
       "--------------------------------------------------\n",
       "\n",
       "Test Mean Absolute Error (MAE): 4107.4230\n",
       "Test Mean Squared Error (MSE): 35807263.0951\n",
-      "Test R-squared (R\u00b2) Score: 0.7526\n",
+      "Test R-squared (R²) Score: 0.7526\n",
       "--------------------------------------------------\n",
       "Training AdaBoost...\n",
       "\n",
       "Train Mean Absolute Error (MAE): 3426.1711\n",
       "Train Mean Squared Error (MSE): 22524073.3138\n",
-      "Train R-squared (R\u00b2) Score: 0.8540\n",
+      "Train R-squared (R²) Score: 0.8540\n",
       "--------------------------------------------------\n",
       "\n",
       "Test Mean Absolute Error (MAE): 3520.1646\n",
       "Test Mean Squared Error (MSE): 24551784.7233\n",
-      "Test R-squared (R\u00b2) Score: 0.8304\n",
+      "Test R-squared (R²) Score: 0.8304\n",
       "--------------------------------------------------\n"
      ]
     }
    ],
    "source": [
     "for model in models:\n",
-    "    create_model_and_predictions(model, X_train_preprocessed, y_train, X_test_preprocessed, y_test)"
+    "    create_model_and_predictions(\n",
+    "        model, X_train_preprocessed, y_train, X_test_preprocessed, y_test\n",
+    "    )"
    ]
   },
   {
@@ -1406,8 +1423,10 @@
     }
    ],
    "source": [
-    "model=RandomForestRegressor()\n",
-    "cross_validation=cross_val_score(model,X_train_preprocessed,y_train, scoring='r2', cv=10)\n",
+    "model = RandomForestRegressor()\n",
+    "cross_validation = cross_val_score(\n",
+    "    model, X_train_preprocessed, y_train, scoring=\"r2\", cv=10\n",
+    ")\n",
     "print(\"Cross-validation scores for each fold:\", cross_validation)\n",
     "\n",
     "print(\"Average cross-validation score:\", cross_validation.mean())"
@@ -1415,6 +1434,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Hyperparameter tuning\n",
@@ -1436,7 +1456,7 @@
     "    \"min_samples_leaf\": [1, 2],\n",
     "    \"max_features\": [\"sqrt\", \"log2\", None],\n",
     "    \"bootstrap\": [True, False],\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -1457,8 +1477,8 @@
    "source": [
     "model = RandomForestRegressor()\n",
     "\n",
-    "grid_search = GridSearchCV(estimator=model, param_grid=param_grid,scoring='r2', cv=10)\n",
-    "grid_search.fit(X_train_preprocessed,y_train)\n",
+    "grid_search = GridSearchCV(estimator=model, param_grid=param_grid, scoring=\"r2\", cv=10)\n",
+    "grid_search.fit(X_train_preprocessed, y_train)\n",
     "\n",
     "print(\"Best Hyperparameters: \", grid_search.best_params_)\n",
     "print(\"Best Score: \", grid_search.best_score_)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "matplotlib",
     "seaborn",
     "pytest>=9.0.2",
+    "ruff>=0.14.14",
 ]
 
 [build-system]
@@ -20,3 +21,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["Data*", "notebook*", "notebooks*"]
+
+[tool.ruff]
+exclude = ["notebooks", "notebook"]

--- a/src/components/data_ingestion.py
+++ b/src/components/data_ingestion.py
@@ -33,7 +33,9 @@ class DataIngestion:
             df = pd.read_csv(source_path)
             logging.info(f"Read dataset from {source_path} with shape {df.shape}")
 
-            os.makedirs(os.path.dirname(self.ingestion_config.train_data_path), exist_ok=True)
+            os.makedirs(
+                os.path.dirname(self.ingestion_config.train_data_path), exist_ok=True
+            )
 
             df.to_csv(self.ingestion_config.raw_data_path, index=False, header=True)
             logging.info(f"Raw dataset saved to {self.ingestion_config.raw_data_path}")
@@ -45,9 +47,13 @@ class DataIngestion:
                 random_state=self.ingestion_config.random_state,
             )
 
-            train_set.to_csv(self.ingestion_config.train_data_path, index=False, header=True)
+            train_set.to_csv(
+                self.ingestion_config.train_data_path, index=False, header=True
+            )
 
-            test_set.to_csv(self.ingestion_config.test_data_path, index=False, header=True)
+            test_set.to_csv(
+                self.ingestion_config.test_data_path, index=False, header=True
+            )
 
             logging.info("Ingestion of the data is completed")
 

--- a/src/exception.py
+++ b/src/exception.py
@@ -1,24 +1,22 @@
 import sys
-from src.logger import logging
 
-def error_message_detail(error,error_detail:sys):
-    _,_,exc_tb=error_detail.exc_info()
-    file_name=exc_tb.tb_frame.f_code.co_filename
-    error_message="Error occured in python script name [{0}] line number [{1}] error message[{2}]".format(
-     file_name,exc_tb.tb_lineno,str(error))
+
+def error_message_detail(error, error_detail: sys):
+    _, _, exc_tb = error_detail.exc_info()
+    file_name = exc_tb.tb_frame.f_code.co_filename
+    error_message = "Error occured in python script name [{0}] line number [{1}] error message[{2}]".format(
+        file_name, exc_tb.tb_lineno, str(error)
+    )
 
     return error_message
 
-    
 
 class CustomException(Exception):
-    def __init__(self,error_message,error_detail:sys):
+    def __init__(self, error_message, error_detail: sys):
         super().__init__(error_message)
-        self.error_message=error_message_detail(error_message,error_detail=error_detail)
-    
+        self.error_message = error_message_detail(
+            error_message, error_detail=error_detail
+        )
+
     def __str__(self):
         return self.error_message
-    
-
-
-        

--- a/src/logger.py
+++ b/src/logger.py
@@ -2,16 +2,14 @@ import logging
 import os
 from datetime import datetime
 
-LOG_FILE=f"{datetime.now().strftime('%m_%d_%Y_%H_%M_%S')}.log"
-logs_path=os.path.join(os.getcwd(),"logs",LOG_FILE)
-os.makedirs(logs_path,exist_ok=True)
+LOG_FILE = f"{datetime.now().strftime('%m_%d_%Y_%H_%M_%S')}.log"
+logs_path = os.path.join(os.getcwd(), "logs", LOG_FILE)
+os.makedirs(logs_path, exist_ok=True)
 
-LOG_FILE_PATH=os.path.join(logs_path,LOG_FILE)
+LOG_FILE_PATH = os.path.join(logs_path, LOG_FILE)
 
 logging.basicConfig(
     filename=LOG_FILE_PATH,
     format="[ %(asctime)s ] %(lineno)d %(name)s - %(levelname)s - %(message)s",
     level=logging.INFO,
-
-
 )

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,14 +1,12 @@
 import os
 import sys
 
-import numpy as np
-import pandas as pd
-import dill
 import pickle
 from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import GridSearchCV
 
 from src.exception import CustomException
+
 
 def save_object(file_path, obj):
     try:
@@ -21,8 +19,9 @@ def save_object(file_path, obj):
 
     except Exception as e:
         raise CustomException(e, sys)
-    
-def evaluate_models(X_train, y_train,X_test,y_test,models,param):
+
+
+def evaluate_models(X_train, y_train, X_test, y_test, models, param):
     try:
         report = {}
         trained_models = {}
@@ -46,16 +45,12 @@ def evaluate_models(X_train, y_train,X_test,y_test,models,param):
                 best_model.fit(X_train, y_train)
 
             if hasattr(best_model, "predict_proba"):
-                y_train_scores = best_model.predict_proba(X_train)[:, 1]
                 y_test_scores = best_model.predict_proba(X_test)[:, 1]
             elif hasattr(best_model, "decision_function"):
-                y_train_scores = best_model.decision_function(X_train)
                 y_test_scores = best_model.decision_function(X_test)
             else:
-                y_train_scores = best_model.predict(X_train)
                 y_test_scores = best_model.predict(X_test)
 
-            train_model_score = roc_auc_score(y_train, y_train_scores)
             test_model_score = roc_auc_score(y_test, y_test_scores)
 
             report[name] = test_model_score
@@ -65,7 +60,8 @@ def evaluate_models(X_train, y_train,X_test,y_test,models,param):
 
     except Exception as e:
         raise CustomException(e, sys)
-    
+
+
 def load_object(file_path):
     try:
         with open(file_path, "rb") as file_obj:

--- a/uv.lock
+++ b/uv.lock
@@ -288,6 +288,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pytest" },
+    { name = "ruff" },
     { name = "scikit-learn" },
     { name = "seaborn" },
 ]
@@ -298,6 +299,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.14.14" },
     { name = "scikit-learn" },
     { name = "seaborn" },
 ]
@@ -546,6 +548,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


## Summary
- Added Ruff linting to CI using `uv run ruff check .`
- Excluded `notebooks/` and `notebook/` from Ruff to avoid linting notebooks
- Fixed unused variable warnings in `src/utils.py`

## Testing
- Not run locally (CI will run Ruff + pytest)

## Notes
- Ruff config lives in `pyproject.toml`
