### PR TITLE
Add MVP docs and repo artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Optional: pull model artifacts from S3 at startup
+MODEL_S3_BUCKET=
+MODEL_S3_MODEL_KEY=model.pkl
+MODEL_S3_PREPROCESSOR_KEY=preprocessor.pkl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-02-02
+### Added
+- FastAPI web UI for manual predictions.
+- /predict form endpoint and /health healthcheck endpoint.
+- End-to-end pipeline runner script.
+- CI tests for ingestion, transformation, training, and prediction.
+- Demo screenshot and live demo link in README.
+
+### Changed
+- Documented API contract, example inputs/outputs, and categorical value enums.
+
+### Fixed
+- README note aligned with default train/test split in code.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# System deps for common scientific packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -21,13 +21,45 @@ Predict medical insurance charges using regression models.
 - smoker: no
 - region: southeast
 
-**Expected output format:**
+**Expected output format (UI):**
 
 - `Estimated insurance charges: <number>`
 
 **API docs:** http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbeanstalk.com/docs
 
 **Try it (curl):**
+
+```bash
+curl -X POST http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbeanstalk.com/predict \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "age=29" \
+  -d "sex=female" \
+  -d "bmi=27.4" \
+  -d "children=2" \
+  -d "smoker=no" \
+  -d "region=southeast"
+```
+
+## MVP API contract
+
+This app currently exposes a form-based `/predict` endpoint that returns HTML.
+Use the following input schema and enums when posting.
+
+**Input schema (form fields)**
+
+- `age` (int)
+- `sex` (enum: `female`, `male`)
+- `bmi` (float)
+- `children` (int)
+- `smoker` (enum: `yes`, `no`)
+- `region` (enum: `northeast`, `northwest`, `southeast`, `southwest`)
+
+**Output**
+
+- UI HTML response contains: `Estimated insurance charges: <number>`
+- Units: USD
+
+**Copy-paste example (form)**
 
 ```bash
 curl -X POST http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbeanstalk.com/predict \
@@ -51,6 +83,21 @@ curl -X POST http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbea
 ```powershell
 uv run python scripts/run_pipeline.py
 ```
+
+### Run the app (local)
+
+```powershell
+uv run python main.py
+```
+
+### Docker (optional)
+
+```powershell
+docker build -t insurance-cost-api .
+docker run --rm -p 8000:8000 insurance-cost-api
+```
+
+Optional environment variables are listed in `.env.example`.
 
 **Architecture overview:** Coming soon. For now, see the live demo preview above.
 
@@ -104,7 +151,7 @@ print("Model score (R2):", score)
 
 ## Notes
 
-- `split_data` uses a default `test_size=0.7` (30/70 train/test).
+- `split_data` uses a default `test_size=0.2` (80/20 train/test).
 - Demo runs in single-instance mode to save cost.
 - HA configs are available (autoscaling + rolling updates) in `deploy/ha/`.
 
@@ -113,6 +160,11 @@ To enable HA:
 ```powershell
 Copy-Item deploy\ha\*.config .ebextensions\
 ```
+
+## Documentation
+
+- Model card: `docs/MODEL_CARD.md`
+- Changelog: `CHANGELOG.md`
 
 ## License
 

--- a/docs/MODEL_CARD.md
+++ b/docs/MODEL_CARD.md
@@ -1,0 +1,43 @@
+# Model Card: Medical Insurance Cost Prediction
+
+## Model Details
+- Problem type: Regression
+- Model: Scikit-learn regressor (see training pipeline for exact estimator)
+- Target: Medical insurance charges (currency in USD)
+
+## Intended Use
+- Estimate insurance charges from user-provided demographic and health-related inputs.
+- For demo/educational use only; not for clinical or pricing decisions.
+
+## Data
+- Source: `Data/medical_insurance.csv`
+- Features used:
+  - age (int)
+  - sex (categorical)
+  - bmi (float)
+  - children (int)
+  - smoker (categorical)
+  - region (categorical)
+- Target: `charges` (float)
+
+## Metrics
+- Primary: R2 (reported by training pipeline)
+- Note: Metrics are reported on the train/test split from the ingestion step.
+
+## Limitations
+- Small, static dataset with limited geographic and demographic coverage.
+- Correlations may not generalize to other populations or policy structures.
+- Sensitive attributes (e.g., sex) are included and may reflect historical bias.
+
+## Fairness and Bias Considerations
+- No formal fairness analysis was performed.
+- The model may encode biases present in the dataset.
+
+## Ethical Considerations
+- Predictions are estimates; use with caution.
+- Not intended for real-world pricing or eligibility decisions.
+
+## How to Improve
+- Collect more diverse and recent data.
+- Add formal bias/fairness evaluation.
+- Provide uncertainty estimates.


### PR DESCRIPTION
# MVP polish: repo-side docs + artifacts

## Summary
Implemented the repo-side MVP polish items: explicit API contract in README, changelog, model card, Dockerfile, and env example; also fixed the README train/test split note.

## Changes made
- Added `CHANGELOG.md` with v0.1.0 notes
- Added `docs/MODEL_CARD.md` (metrics, data source, limitations, fairness note)
- Added `Dockerfile` for running the FastAPI app
- Added `.env.example` for optional S3 artifact loading
- Updated `README.md`:
  - MVP API contract (schema, enums, output, copy‑paste request)
  - Local run + Docker instructions
  - Fixed `test_size` note (now 0.2 / 80-20)
  - Linked model card + changelog

## Files
- `README.md`
- `CHANGELOG.md`
- `docs/MODEL_CARD.md`
- `Dockerfile`
- `.env.example`

## Checklist
- [x] MVP API contract in README
- [x] Changelog added
- [x] Model card added
- [x] Dockerfile added
- [x] .env.example added
- [x] README note aligned with code split

## Follow-ups (GitHub UI)
- [ ] Set About/Website/Topics in GitHub repo settings
- [ ] Create v0.1.0 release tag + GitHub Release notes
