### PR TITLE
Add JSON prediction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ curl -X POST http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbea
   -d "region=southeast"
 ```
 
+### JSON endpoint
+
+Use `/predict-json` for API integrations that need a stable JSON schema.
+
+**JSON request**
+
+```bash
+curl -X POST http://medical-insurance-cost-env.eba-pswdedzm.us-east-1.elasticbeanstalk.com/predict-json \
+  -H "Content-Type: application/json" \
+  -d '{"age": 29, "sex": "female", "bmi": 27.4, "children": 2, "smoker": "no", "region": "southeast"}'
+```
+
+**JSON response**
+
+```json
+{
+  "predicted_charges": 12345.67,
+  "currency": "USD"
+}
+```
+
 ## Demo highlights
 
 - End-to-end pipeline from raw CSV to trained model and predictions.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
-from fastapi import FastAPI, Form, Request
+from typing import Literal
+
+from fastapi import FastAPI, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
 
 from pipeline.predict_pipeline import CustomData, PredictPipeline
 
@@ -72,3 +75,44 @@ async def predict_datapoint(
         "home.html",
         {"results": result_text, "error_message": None},
     )
+
+
+class PredictionRequest(BaseModel):
+    age: int = Field(..., ge=0)
+    sex: Literal["female", "male"]
+    bmi: float = Field(..., gt=0)
+    children: int = Field(..., ge=0)
+    smoker: Literal["yes", "no"]
+    region: Literal["northeast", "northwest", "southeast", "southwest"]
+
+    model_config = {"extra": "forbid"}
+
+
+class PredictionResponse(BaseModel):
+    predicted_charges: float
+    currency: str = "USD"
+
+
+@app.post("/predict-json", response_model=PredictionResponse)
+async def predict_json(payload: PredictionRequest):
+    data = CustomData(
+        age=payload.age,
+        sex=payload.sex,
+        bmi=payload.bmi,
+        children=payload.children,
+        smoker=payload.smoker,
+        region=payload.region,
+    )
+
+    pred_df = data.get_data_as_data_frame()
+    predict_pipeline = PredictPipeline()
+
+    try:
+        results = predict_pipeline.predict(pred_df)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Prediction failed. Check logs for details.",
+        ) from exc
+
+    return PredictionResponse(predicted_charges=float(results[0]))

--- a/tests/test_fastapi_smoke.py
+++ b/tests/test_fastapi_smoke.py
@@ -67,3 +67,28 @@ def test_fastapi_smoke(tmp_path, monkeypatch):
     response = client.post("/predict", data=payload)
     assert response.status_code == 200
     assert "Estimated insurance charges" in response.text
+
+    json_payload = {
+        "age": 19,
+        "sex": "female",
+        "bmi": 27.9,
+        "children": 0,
+        "smoker": "yes",
+        "region": "southwest",
+    }
+    response = client.post("/predict-json", json=json_payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert "predicted_charges" in body
+    assert body["currency"] == "USD"
+
+    invalid_payload = {
+        "age": 19,
+        "sex": "female",
+        "bmi": 27.9,
+        "children": 0,
+        "smoker": "yes",
+        "region": "invalid",
+    }
+    response = client.post("/predict-json", json=invalid_payload)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
Adds a JSON prediction endpoint with a stable response schema and documents it in the README.

## Changes
- Added `/predict-json` with Pydantic validation and JSON response schema
- Documented JSON request/response in README
- Extended FastAPI smoke test to cover JSON endpoint and validation errors

## Testing
- `python -m pytest tests/test_fastapi_smoke.py`

## Closes
- Closes #<issue-number>
