### PR TITLE
Add Makefile and docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test lint pipeline
+
+setup:
+	python -m pip install -r requirements.txt
+
+run:
+	uv run python main.py
+
+test:
+	python -m pytest
+
+lint:
+	python -m ruff check .
+
+pipeline:
+	uv run python scripts/run_pipeline.py

--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ docker run --rm -p 8000:8000 insurance-cost-api
 
 Optional environment variables are listed in `.env.example`.
 
+### Docker Compose (optional)
+
+```powershell
+docker-compose up --build
+```
+
+### Makefile helpers (optional)
+
+```powershell
+make setup
+make run
+make test
+make lint
+make pipeline
+```
+
 **Architecture overview:** Coming soon. For now, see the live demo preview above.
 
 ## Project structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env


### PR DESCRIPTION
## Summary
Adds a Makefile and docker-compose config to simplify local development, plus README docs for both.

## Changes
- Added `Makefile` with setup/run/test/lint/pipeline targets
- Added `docker-compose.yml` for running the FastAPI app
- Updated README with Makefile and docker-compose usage

## Testing
- Not run (Make installed locally; no CI run)

## Closes
- Closes #30 
